### PR TITLE
UsbDeviceManager: Check PTP FileDescriptor properly

### DIFF
--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
@@ -279,8 +279,8 @@ public class UsbDeviceManager implements ActivityManagerInternal.ScreenObserver 
         }
         mControlFds.put(UsbManager.FUNCTION_MTP, mtpFd);
         FileDescriptor ptpFd = nativeOpenControl(UsbManager.USB_FUNCTION_PTP);
-        if (mtpFd == null) {
-            Slog.e(TAG, "Failed to open control for mtp");
+        if (ptpFd == null) {
+            Slog.e(TAG, "Failed to open control for ptp");
         }
         mControlFds.put(UsbManager.FUNCTION_PTP, ptpFd);
 


### PR DESCRIPTION
 * A typo causes MTP one to be checked twice

Change-Id: If16bf5df43b6d51f6717aa7994b2f428fb3f1a69